### PR TITLE
Add StartupWMClass to lsi-steam.desktop

### DIFF
--- a/data/lsi-steam.desktop
+++ b/data/lsi-steam.desktop
@@ -8,6 +8,7 @@ Type=Application
 Categories=Network;FileTransfer;Game;
 MimeType=x-scheme-handler/steam;
 Actions=Store;Community;Library;Servers;Screenshots;News;Settings;BigPicture;Friends;
+StartupWMClass=Steam
 
 [Desktop Action Store]
 Name=Store


### PR DESCRIPTION
In gnome shell adding LSI-Steam to Favourites and launching it from there opens Steam under a new "icon". 
This makes it so the LSI-Steam icon owns any steam instance launched from it.

Fixes #53 