### PR TITLE
intercept: Handle override of libva.so.1 -> libva.so.2, libva-x11.so.1 -> libva-x11.so.2

### DIFF
--- a/src/intercept/main.c
+++ b/src/intercept/main.c
@@ -276,6 +276,9 @@ static const char *vendor_transmute_source[] = {
         "libbz2.so.1.0",
 
         "libudev.so.0",
+
+        "libva.so.1",
+        "libva-x11.so.1",
 };
 
 /**
@@ -318,6 +321,9 @@ static const char *vendor_transmute_target[] = {
         "libbz2.so.1.0.6",
 
         "libudev.so.1",
+
+        "libva.so.2",
+        "libva-x11.so.2",
 };
 
 /**


### PR DESCRIPTION
Fixed issue when Steam can't find libva.so.1 and libva-x11.so.1
because libva have bumped version to 2.1.0 (>= 2.0.0). The issue 
causes failed to load steamui.

Fixed https://github.com/solus-project/linux-steam-integration/issues/67